### PR TITLE
Modularize environment variables

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -22,9 +22,9 @@ var commandRegistry = map[string]CommandFunc{
 	"cw":       general.CW,
 	"calc":     general.CalculateCommand,
 	"eval":     general.CalculateCommand,
-	"loc":      location.Location,
-	"location": location.Location,
-	"w":        location.Weather,
-	"weather":  location.Weather,
-	"osu":      osuCommands.Osu,
+	"loc":      location.Location, // requires aprs.fi
+	"location": location.Location, // requires aprs.fi
+	"w":        location.Weather,  // requires aprs.fi + weather keys
+	"weather":  location.Weather,  // requires aprs.fi + weather keys
+	"osu":      osuCommands.Osu,   // requires osu_client_id + osu_client_secret
 }

--- a/helpers/api/api.go
+++ b/helpers/api/api.go
@@ -1,16 +1,17 @@
 package api
 
 import (
+	"fmt"
 	"simpleAPRSbot-go/helpers/api/OpenWeatherMap"
 	"simpleAPRSbot-go/helpers/api/aprsFi"
 	"simpleAPRSbot-go/helpers/api/osu"
 )
 
 type Keys struct {
-	APRSFIkey         string
-	OpenWeatherMapKey string
-	OsuClientID       int
-	OsuClientSecret   string
+	APRSFIkey         *string
+	OpenWeatherMapKey *string
+	OsuClientID       *int
+	OsuClientSecret   *string
 }
 
 type Clients struct {
@@ -19,12 +20,32 @@ type Clients struct {
 	OSUClient            *osu.OsuAPIClient
 }
 
-func InitializeAPIClients(apiKeys Keys) Clients {
-	var APRSFIClient = AprsFi.InitializeAprsFiClient(apiKeys.APRSFIkey)
-	var OpenWeatherMapClient = OpenWeatherMap.New(apiKeys.OpenWeatherMapKey)
-	var OsuClient, _ = osu.InitializeOsuClient(apiKeys.OsuClientID, apiKeys.OsuClientSecret, "client_credentials")
-	return Clients{APRSFi: APRSFIClient,
-		OpenWeatherMapClient: OpenWeatherMapClient,
-		OSUClient:            OsuClient,
+func InitializeAPIClients(apiKeys *Keys) Clients {
+	var returnObject = Clients{}
+	//first we need to check if the provided keys are nil
+	if apiKeys.OpenWeatherMapKey != nil {
+		// we nest this so that we don't get a nil-pointer deref
+		if *apiKeys.OpenWeatherMapKey != "" {
+			returnObject.OpenWeatherMapClient = OpenWeatherMap.New(*apiKeys.OpenWeatherMapKey)
+		}
 	}
+	if apiKeys.APRSFIkey != nil {
+		if *apiKeys.APRSFIkey != "" {
+			returnObject.APRSFi = AprsFi.InitializeAprsFiClient(*apiKeys.APRSFIkey)
+		}
+	}
+	if apiKeys.OsuClientID != nil || apiKeys.OsuClientSecret != nil {
+		var OSUClient *osu.OsuAPIClient
+		var err error
+		if *apiKeys.OsuClientID != 0 && *apiKeys.OsuClientSecret != "" {
+			OSUClient, err = osu.InitializeOsuClient(*apiKeys.OsuClientID, *apiKeys.OsuClientSecret, "client_credentials")
+			if err != nil {
+				fmt.Println("Error initializing Osu Client")
+				returnObject.OSUClient = nil
+			}
+		}
+
+		returnObject.OSUClient = OSUClient
+	}
+	return returnObject
 }

--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,11 @@ Edit the docker-compose file with your api keys
 
 docker-compose up
 
-## Required Environment Variables
+### Required Environment Variables
 APRS_CALL= <br>
 APRS_PASS= <br>
+
+### Optional Environment Vars
 APRS_FI_API_KEY= <br>
 OWM_API_KEY= <br>
 OSU_CLIENT_ID= <br>


### PR DESCRIPTION
This makes it so that only `APRS_CALL` and `APRS_PASSWORD` are required environment variables. This is accomplished by disabling some commands when initializing the APRS client based on what env. vars are passed in. To disable a command, we just remove the command and it's aliases from the `commandRegistry` map. Also ended up having to basically re-write how API clients are initialized, as to ensure they don't error constantly when provided nil-value keys. 